### PR TITLE
Metadata: Enable Multi-author documents and Increase entity richness for...

### DIFF
--- a/examples/pizza-parlor.json
+++ b/examples/pizza-parlor.json
@@ -3,7 +3,22 @@
   {
     "title": "Pizza Parlor PCN",
     "description": "This PCN represents the different interactions between a pizza restaurant and a customer.",
-    "author": "Morgan Young"
+    "creationDate": "",
+    "authors": 
+      [
+        {
+          "name":"Morgan Young",
+          "id":"GUID_1111",
+          "organization":"",
+          "site":""
+        },
+        {
+          "name":"Matt Swensen",
+          "id":"GUID_1112",
+          "organization":"",
+          "site":""
+        },
+      ]
   },
 
   "domains":


### PR DESCRIPTION
... authors

Make it possible to list multiple authors on a given document.
Also, increase the richness of authors as entities to increase interactiveness in a document (for instance, creating explorable, clickable names on front-end visualizations of data, working towards the possibility of uniquely identifying author edits, etc.).
This could be expanded out in different ways, but this is a proposal to create a basic initial effort here.

Also, adding a creationDate to metadata.
