### PR TITLE
Update Spec Documentation for Readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ For complete examples of the standard that use real-world data, please see the [
 
 ## Specification
 
+### Top Level
+
 ```js
 /**
  * PCN data specification
@@ -67,200 +69,212 @@ For complete examples of the standard that use real-world data, please see the [
    * analysis.
    * @type {Array.<Object>}
    */
-  "domains": [
-    {
-      /**
-       * The id field should contain a unique identifier in string form.
-       * @type {string}
-       */
-      "id": "",
-
-      /**
-       * The title field is used to describe the domain and will usually be
-       * filled with the name of the firm or customer segment.
-       * @type {string}
-       * @example "IKEA"
-       */
-      "title": "",
-
-      /**
-       * The subtitle field can be used for additional information about domain,
-       * and will typically denote whether the domain is the provider, the
-       * customer, or both.
-       * @type {string}
-       * @example "Provider"
-       */
-      "subtitle": ""
-    }
-  ],
+  "domains": [],
 
   /**
    * The steps field is where the substance of the analyzed process resides.
    * @type {Array.<Object>}
    */
-  "steps": [
+  "steps": []
+}
+```
+### Domain ###
+
+The domains field contains representations of the domains pertaining to the analysis.
+
+```js
+{
+  /**
+   * The id field should contain a unique identifier in string form.
+   * @type {string}
+   */
+  "id": "",
+
+  /**
+   * The title field is used to describe the domain and will usually be
+   * filled with the name of the firm or customer segment.
+   * @type {string}
+   * @example "IKEA"
+   */
+  "title": "",
+
+  /**
+   * The subtitle field can be used for additional information about domain,
+   * and will typically denote whether the domain is the provider, the
+   * customer, or both.
+   * @type {string}
+   * @example "Provider"
+   */
+  "subtitle": ""
+}
+```
+
+### Steps ###
+
+The steps field is where the substance of the analyzed process resides.
+
+```js
+
+{
+  /**
+   * A unique identifier for the step.
+   * @type {string}
+   */
+  "id": "",
+
+  /**
+   * The description of the step.
+   * @type {string}
+   */
+  "title": "",
+
+  /**
+   * The type of the step. The value must be one of:
+   * - "process" - a standard process step
+   * - "decision" - a step that represents a decision
+   * - "wait" - a step that requires a waiting period
+   *   in graphical representations of the PCN analysis
+   * - "divergent_process" - a step that requires human judgment
+   * @type {string}
+   */
+  "type": "",
+
+  /**
+   * An optional boolean that indicates whether or not the process is
+   * relatively more significant.
+   * @type {boolean}
+   * @optional
+   */
+  "emphasized": false,
+
+  /**
+   * The value_specific field represents the value realization or value
+   * potential that the specific beneficiary receives during the step. The
+   * value of this field must be an integer (may be negative).
+   * @type {number}
+   * @example 3 (much value realization or potential, perhaps represented by
+   *   three smiley faces on a typical PCN diagram)
+   * @example 0 (no or neutral value realization)
+   * @example -1 (non-monetary cost, perhaps represented graphically by a
+   *   frown face)
+   */
+  "value_specific": 0,
+
+  /**
+   * The value_generic field is identical to the value_specific field,
+   * except that it represents the value potential or value realization of
+   * the generic beneficiary instead of the specific beneficiary. Positive
+   * values might be represented graphically by dollar signs, and negative
+   * values by dollar signs with negative symbols.
+   * @type {number}
+   */
+  "value_generic": 0,
+
+  /**
+   * The predecessors field defines relationships between the step and other
+   * steps. The field is optional and will be omitted for steps that have no
+   * predecessors, such as the first step of a process. It will have
+   * multiple entries for steps that are a point of convergence in a
+   * process.
+   * @type {Array.<Object>}
+   * @optional
+   */
+  "predecessors": [
     {
       /**
-       * A unique identifier for the step.
+       * The identifier of the predecessor step.
        * @type {string}
        */
       "id": "",
 
       /**
-       * The description of the step.
-       * @type {string}
-       */
-      "title": "",
-
-      /**
-       * The type of the step. The value must be one of:
-       * - "process" - a standard process step
-       * - "decision" - a step that represents a decision
-       * - "wait" - a step that requires a waiting period
-       *   in graphical representations of the PCN analysis
-       * - "divergent_process" - a step that requires human judgment
+       * The type of relationship with the predecessor. Must be one of:
+       * - "normal_relationship" - Typically represented on a PCN diagram by
+       *   a solid line.
+       * - "loose_temporal_relationship" - Typically represented on a PCN
+       *   diagram by a dashed line.
        * @type {string}
        */
       "type": "",
 
       /**
-       * An optional boolean that indicates whether or not the process is
-       * relatively more significant.
-       * @type {boolean}
+       * The optional title field provides additional information about the
+       * relationship between the steps. For example, "Yes" or "No" might be
+       * used for steps that are successors to decision steps.
+       * @type {string}
        * @optional
        */
-      "emphasized": false,
+      "title": ""
+    }
+  ],
+
+  /**
+   * The domain field links the step to the domain it is associated with,
+   * which are defined in the top-level domains field.
+   */
+  "domain": {
+
+    /**
+     * The identifier of the domain that the step is associated with.
+     * @type {string}
+     */
+    "id": "",
+
+    /**
+     * The process region that the step is in. An object with the two fields
+     * outlined below.
+     * @type {Object}
+     */
+    "region": {
 
       /**
-       * The value_specific field represents the value realization or value
-       * potential that the specific beneficiary receives during the step. The
-       * value of this field must be an integer (may be negative).
-       * @type {number}
-       * @example 3 (much value realization or potential, perhaps represented by
-       *   three smiley faces on a typical PCN diagram)
-       * @example 0 (no or neutral value realization)
-       * @example -1 (non-monetary cost, perhaps represented graphically by a
-       *   frown face)
+       * The type field identifies the region, and must be one of:
+       * - "independent" - the independent processing region of the domain
+       * - "surrogate" - one of the surrogate regions of the domain
+       * - "direct_leading" - one of the direct interaction regions of the
+       *   domain, with preference to the domain's side of the region
+       * - "direct_shared" - one of the direct interaction regions of the
+       *   domain, in the middle of the region
+       * See the with_domain field below.
+       * @type {string}
        */
-      "value_specific": 0,
+      "type": "",
 
       /**
-       * The value_generic field is identical to the value_specific field,
-       * except that it represents the value potential or value realization of
-       * the generic beneficiary instead of the specific beneficiary. Positive
-       * values might be represented graphically by dollar signs, and negative
-       * values by dollar signs with negative symbols.
-       * @type {number}
+       * If the above type field is anything but "independent", the
+       * with_domain field is the identifier of the other domain involved
+       * in the process. This field determines which of the two surrogate
+       * or direct regions the step falls under. If the above type field is
+       * "independent", the value of this field should be ignored.
+       * @type {string}
        */
-      "value_generic": 0,
+      "with_domain": ""
+    }
+  },
+
+  /**
+   * The problems field represents potential issues with the step.
+   * @type {Array.<Object>}
+   * @optional
+   */
+  "problems": [
+    {
+      /**
+       * The type of problem must be one of:
+       * - "inconvenient"
+       * - "confusing"
+       * - "difficult"
+       * - "likely_to_fail"
+       * @type {string}
+       */
+      "type": "",
 
       /**
-       * The predecessors field defines relationships between the step and other
-       * steps. The field is optional and will be omitted for steps that have no
-       * predecessors, such as the first step of a process. It will have
-       * multiple entries for steps that are a point of convergence in a
-       * process.
-       * @type {Array.<Object>}
-       * @optional
+       * The description field builds upon the type field and provides the
+       * why or how of the problem.
+       * @type {string}
        */
-      "predecessors": [
-        {
-          /**
-           * The identifier of the predecessor step.
-           * @type {string}
-           */
-          "id": "",
-
-          /**
-           * The type of relationship with the predecessor. Must be one of:
-           * - "normal_relationship" - Typically represented on a PCN diagram by
-           *   a solid line.
-           * - "loose_temporal_relationship" - Typically represented on a PCN
-           *   diagram by a dashed line.
-           * @type {string}
-           */
-          "type": "",
-
-          /**
-           * The optional title field provides additional information about the
-           * relationship between the steps. For example, "Yes" or "No" might be
-           * used for steps that are successors to decision steps.
-           * @type {string}
-           * @optional
-           */
-          "title": ""
-        }
-      ],
-
-      /**
-       * The domain field links the step to the domain it is associated with,
-       * which are defined in the top-level domains field.
-       */
-      "domain": {
-
-        /**
-         * The identifier of the domain that the step is associated with.
-         * @type {string}
-         */
-        "id": "",
-
-        /**
-         * The process region that the step is in. An object with the two fields
-         * outlined below.
-         * @type {Object}
-         */
-        "region": {
-
-          /**
-           * The type field identifies the region, and must be one of:
-           * - "independent" - the independent processing region of the domain
-           * - "surrogate" - one of the surrogate regions of the domain
-           * - "direct_leading" - one of the direct interaction regions of the
-           *   domain, with preference to the domain's side of the region
-           * - "direct_shared" - one of the direct interaction regions of the
-           *   domain, in the middle of the region
-           * See the with_domain field below.
-           * @type {string}
-           */
-          "type": "",
-
-          /**
-           * If the above type field is anything but "independent", the
-           * with_domain field is the identifier of the other domain involved
-           * in the process. This field determines which of the two surrogate
-           * or direct regions the step falls under. If the above type field is
-           * "independent", the value of this field should be ignored.
-           * @type {string}
-           */
-          "with_domain": ""
-        }
-      },
-
-      /**
-       * The problems field represents potential issues with the step.
-       * @type {Array.<Object>}
-       * @optional
-       */
-      "problems": [
-        {
-          /**
-           * The type of problem must be one of:
-           * - "inconvenient"
-           * - "confusing"
-           * - "difficult"
-           * - "likely_to_fail"
-           * @type {string}
-           */
-          "type": "",
-
-          /**
-           * The description field builds upon the type field and provides the
-           * why or how of the problem.
-           * @type {string}
-           */
-          "description": ""
-        }
-      ]
+      "description": ""
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ For complete examples of the standard that use real-world data, please see the [
 
 ## Specification
 
-### Top Level ###
-
 ```js
 /**
  * PCN data specification
@@ -66,213 +64,202 @@ For complete examples of the standard that use real-world data, please see the [
 
   /**
    * The domains field contains representations of the domains pertaining to the
-   * analysis.  Formatted as Domain objects.
+   * analysis.
    * @type {Array.<Object>}
    */
-  "domains": [],
-
-  /**
-   * The steps field is where the substance of the analyzed process resides.
-   * Formatted as Step objects.
-   * @type {Array.<Object>}
-   */
-  "steps": []
-}
-```
-### Domain ###
-
-Specification for a *Domain* object:
-
-```js
-{
-  /**
-   * The id field should contain a unique identifier in string form.
-   * @type {string}
-   */
-  "id": "",
-
-  /**
-   * The title field is used to describe the domain and will usually be
-   * filled with the name of the firm or customer segment.
-   * @type {string}
-   * @example "IKEA"
-   */
-  "title": "",
-
-  /**
-   * The subtitle field can be used for additional information about domain,
-   * and will typically denote whether the domain is the provider, the
-   * customer, or both.
-   * @type {string}
-   * @example "Provider"
-   */
-  "subtitle": ""
-}
-```
-### Step ###
-
-Specification for a *Step* object.
-
-```js
-{
-  /**
-   * A unique identifier for the step.
-   * @type {string}
-   */
-  "id": "",
-
-  /**
-   * The description of the step.
-   * @type {string}
-   */
-  "title": "",
-
-  /**
-   * The type of the step. The value must be one of:
-   * - "process" - a standard process step
-   * - "decision" - a step that represents a decision
-   * - "wait" - a step that requires a waiting period
-   *   in graphical representations of the PCN analysis
-   * - "divergent_process" - a step that requires human judgment
-   * @type {string}
-   */
-  "type": "",
-
-  /**
-   * An optional boolean that indicates whether or not the process is
-   * relatively more significant.
-   * @type {boolean}
-   * @optional
-   */
-  "emphasized": false,
-
-  /**
-   * The value_specific field represents the value realization or value
-   * potential that the specific beneficiary receives during the step. The
-   * value of this field must be an integer (may be negative).
-   * @type {number}
-   * @example 3 (much value realization or potential, perhaps represented by
-   *   three smiley faces on a typical PCN diagram)
-   * @example 0 (no or neutral value realization)
-   * @example -1 (non-monetary cost, perhaps represented graphically by a
-   *   frown face)
-   */
-  "value_specific": 0,
-
-  /**
-   * The value_generic field is identical to the value_specific field,
-   * except that it represents the value potential or value realization of
-   * the generic beneficiary instead of the specific beneficiary. Positive
-   * values might be represented graphically by dollar signs, and negative
-   * values by dollar signs with negative symbols.
-   * @type {number}
-   */
-  "value_generic": 0,
-
-  /**
-   * The predecessors field defines relationships between the step and other
-   * steps. The field is optional and will be omitted for steps that have no
-   * predecessors, such as the first step of a process. It will have
-   * multiple entries for steps that are a point of convergence in a
-   * process.
-   * @type {Array.<Object>}
-   * @optional
-   */
-  "predecessors": [
+  "domains": [
     {
       /**
-       * The identifier of the predecessor step.
+       * The id field should contain a unique identifier in string form.
        * @type {string}
        */
       "id": "",
 
       /**
-       * The type of relationship with the predecessor. Must be one of:
-       * - "normal_relationship" - Typically represented on a PCN diagram by
-       *   a solid line.
-       * - "loose_temporal_relationship" - Typically represented on a PCN
-       *   diagram by a dashed line.
+       * The title field is used to describe the domain and will usually be
+       * filled with the name of the firm or customer segment.
        * @type {string}
+       * @example "IKEA"
        */
-      "type": "",
+      "title": "",
 
       /**
-       * The optional title field provides additional information about the
-       * relationship between the steps. For example, "Yes" or "No" might be
-       * used for steps that are successors to decision steps.
+       * The subtitle field can be used for additional information about domain,
+       * and will typically denote whether the domain is the provider, the
+       * customer, or both.
        * @type {string}
-       * @optional
+       * @example "Provider"
        */
-      "title": ""
+      "subtitle": ""
     }
   ],
 
   /**
-   * The domain field links the step to the domain it is associated with,
-   * which are defined in the top-level domains field.
-   */
-  "domain": {
-
-    /**
-     * The identifier of the domain that the step is associated with.
-     * @type {string}
-     */
-    "id": "",
-
-    /**
-     * The process region that the step is in. An object with the two fields
-     * outlined below.
-     * @type {Object}
-     */
-    "region": {
-
-      /**
-       * The type field identifies the region, and must be one of:
-       * - "independent" - the independent processing region of the domain
-       * - "surrogate" - one of the surrogate regions of the domain
-       * - "direct_TODO" - one of the direct interaction regions of the
-       *   domain, with preference to the domain's side of the region
-       * - "direct" - one of the direct interaction regions of the domain,
-       *   in the middle of the region
-       * See the with_domain field below.
-       */
-      "type": "",
-
-      /**
-       * If the above type field is anything but "independent", the
-       * with_domain field is the identifier of the other domain involved
-       * in the process. This field determines which of the two surrogate
-       * or direct regions the step falls under. If the above type field is
-       * "independent", the value of this field should be ignored.
-       * @type {string}
-       */
-      "with_domain": ""
-    }
-  },
-
-  /**
-   * The problems field represents potential issues with the step.
+   * The steps field is where the substance of the analyzed process resides.
    * @type {Array.<Object>}
-   * @optional
    */
-  "problems": [
+  "steps": [
     {
       /**
-       * The type of problem must be one of:
-       * - "inconvenient"
-       * - "confusing"
-       * - "difficult"
-       * - "likely_to_fail"
+       * A unique identifier for the step.
+       * @type {string}
+       */
+      "id": "",
+
+      /**
+       * The description of the step.
+       * @type {string}
+       */
+      "title": "",
+
+      /**
+       * The type of the step. The value must be one of:
+       * - "process" - a standard process step
+       * - "decision" - a step that represents a decision
+       * - "wait" - a step that requires a waiting period
+       *   in graphical representations of the PCN analysis
+       * - "divergent_process" - a step that requires human judgment
        * @type {string}
        */
       "type": "",
 
       /**
-       * The description field builds upon the type field and provides the
-       * why or how of the problem.
-       * @type {string}
+       * An optional boolean that indicates whether or not the process is
+       * relatively more significant.
+       * @type {boolean}
+       * @optional
        */
-      "description": ""
+      "emphasized": false,
+
+      /**
+       * The value_specific field represents the value realization or value
+       * potential that the specific beneficiary receives during the step. The
+       * value of this field must be an integer (may be negative).
+       * @type {number}
+       * @example 3 (much value realization or potential, perhaps represented by
+       *   three smiley faces on a typical PCN diagram)
+       * @example 0 (no or neutral value realization)
+       * @example -1 (non-monetary cost, perhaps represented graphically by a
+       *   frown face)
+       */
+      "value_specific": 0,
+
+      /**
+       * The value_generic field is identical to the value_specific field,
+       * except that it represents the value potential or value realization of
+       * the generic beneficiary instead of the specific beneficiary. Positive
+       * values might be represented graphically by dollar signs, and negative
+       * values by dollar signs with negative symbols.
+       * @type {number}
+       */
+      "value_generic": 0,
+
+      /**
+       * The predecessors field defines relationships between the step and other
+       * steps. The field is optional and will be omitted for steps that have no
+       * predecessors, such as the first step of a process. It will have
+       * multiple entries for steps that are a point of convergence in a
+       * process.
+       * @type {Array.<Object>}
+       * @optional
+       */
+      "predecessors": [
+        {
+          /**
+           * The identifier of the predecessor step.
+           * @type {string}
+           */
+          "id": "",
+
+          /**
+           * The type of relationship with the predecessor. Must be one of:
+           * - "normal_relationship" - Typically represented on a PCN diagram by
+           *   a solid line.
+           * - "loose_temporal_relationship" - Typically represented on a PCN
+           *   diagram by a dashed line.
+           * @type {string}
+           */
+          "type": "",
+
+          /**
+           * The optional title field provides additional information about the
+           * relationship between the steps. For example, "Yes" or "No" might be
+           * used for steps that are successors to decision steps.
+           * @type {string}
+           * @optional
+           */
+          "title": ""
+        }
+      ],
+
+      /**
+       * The domain field links the step to the domain it is associated with,
+       * which are defined in the top-level domains field.
+       */
+      "domain": {
+
+        /**
+         * The identifier of the domain that the step is associated with.
+         * @type {string}
+         */
+        "id": "",
+
+        /**
+         * The process region that the step is in. An object with the two fields
+         * outlined below.
+         * @type {Object}
+         */
+        "region": {
+
+          /**
+           * The type field identifies the region, and must be one of:
+           * - "independent" - the independent processing region of the domain
+           * - "surrogate" - one of the surrogate regions of the domain
+           * - "direct_TODO" - one of the direct interaction regions of the
+           *   domain, with preference to the domain's side of the region
+           * - "direct" - one of the direct interaction regions of the domain,
+           *   in the middle of the region
+           * See the with_domain field below.
+           */
+          "type": "",
+
+          /**
+           * If the above type field is anything but "independent", the
+           * with_domain field is the identifier of the other domain involved
+           * in the process. This field determines which of the two surrogate
+           * or direct regions the step falls under. If the above type field is
+           * "independent", the value of this field should be ignored.
+           * @type {string}
+           */
+          "with_domain": ""
+        }
+      },
+
+      /**
+       * The problems field represents potential issues with the step.
+       * @type {Array.<Object>}
+       * @optional
+       */
+      "problems": [
+        {
+          /**
+           * The type of problem must be one of:
+           * - "inconvenient"
+           * - "confusing"
+           * - "difficult"
+           * - "likely_to_fail"
+           * @type {string}
+           */
+          "type": "",
+
+          /**
+           * The description field builds upon the type field and provides the
+           * why or how of the problem.
+           * @type {string}
+           */
+          "description": ""
+        }
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ For complete examples of the standard that use real-world data, please see the [
 
 ## Specification
 
+### Top Level ###
+
 ```js
 /**
  * PCN data specification
@@ -64,202 +66,213 @@ For complete examples of the standard that use real-world data, please see the [
 
   /**
    * The domains field contains representations of the domains pertaining to the
-   * analysis.
+   * analysis.  Formatted as Domain objects.
    * @type {Array.<Object>}
    */
-  "domains": [
-    {
-      /**
-       * The id field should contain a unique identifier in string form.
-       * @type {string}
-       */
-      "id": "",
-
-      /**
-       * The title field is used to describe the domain and will usually be
-       * filled with the name of the firm or customer segment.
-       * @type {string}
-       * @example "IKEA"
-       */
-      "title": "",
-
-      /**
-       * The subtitle field can be used for additional information about domain,
-       * and will typically denote whether the domain is the provider, the
-       * customer, or both.
-       * @type {string}
-       * @example "Provider"
-       */
-      "subtitle": ""
-    }
-  ],
+  "domains": [],
 
   /**
    * The steps field is where the substance of the analyzed process resides.
+   * Formatted as Step objects.
    * @type {Array.<Object>}
    */
-  "steps": [
+  "steps": []
+}
+```
+### Domain ###
+
+Specification for a *Domain* object:
+
+```js
+{
+  /**
+   * The id field should contain a unique identifier in string form.
+   * @type {string}
+   */
+  "id": "",
+
+  /**
+   * The title field is used to describe the domain and will usually be
+   * filled with the name of the firm or customer segment.
+   * @type {string}
+   * @example "IKEA"
+   */
+  "title": "",
+
+  /**
+   * The subtitle field can be used for additional information about domain,
+   * and will typically denote whether the domain is the provider, the
+   * customer, or both.
+   * @type {string}
+   * @example "Provider"
+   */
+  "subtitle": ""
+}
+```
+### Step ###
+
+Specification for a *Step* object.
+
+```js
+{
+  /**
+   * A unique identifier for the step.
+   * @type {string}
+   */
+  "id": "",
+
+  /**
+   * The description of the step.
+   * @type {string}
+   */
+  "title": "",
+
+  /**
+   * The type of the step. The value must be one of:
+   * - "process" - a standard process step
+   * - "decision" - a step that represents a decision
+   * - "wait" - a step that requires a waiting period
+   *   in graphical representations of the PCN analysis
+   * - "divergent_process" - a step that requires human judgment
+   * @type {string}
+   */
+  "type": "",
+
+  /**
+   * An optional boolean that indicates whether or not the process is
+   * relatively more significant.
+   * @type {boolean}
+   * @optional
+   */
+  "emphasized": false,
+
+  /**
+   * The value_specific field represents the value realization or value
+   * potential that the specific beneficiary receives during the step. The
+   * value of this field must be an integer (may be negative).
+   * @type {number}
+   * @example 3 (much value realization or potential, perhaps represented by
+   *   three smiley faces on a typical PCN diagram)
+   * @example 0 (no or neutral value realization)
+   * @example -1 (non-monetary cost, perhaps represented graphically by a
+   *   frown face)
+   */
+  "value_specific": 0,
+
+  /**
+   * The value_generic field is identical to the value_specific field,
+   * except that it represents the value potential or value realization of
+   * the generic beneficiary instead of the specific beneficiary. Positive
+   * values might be represented graphically by dollar signs, and negative
+   * values by dollar signs with negative symbols.
+   * @type {number}
+   */
+  "value_generic": 0,
+
+  /**
+   * The predecessors field defines relationships between the step and other
+   * steps. The field is optional and will be omitted for steps that have no
+   * predecessors, such as the first step of a process. It will have
+   * multiple entries for steps that are a point of convergence in a
+   * process.
+   * @type {Array.<Object>}
+   * @optional
+   */
+  "predecessors": [
     {
       /**
-       * A unique identifier for the step.
+       * The identifier of the predecessor step.
        * @type {string}
        */
       "id": "",
 
       /**
-       * The description of the step.
-       * @type {string}
-       */
-      "title": "",
-
-      /**
-       * The type of the step. The value must be one of:
-       * - "process" - a standard process step
-       * - "decision" - a step that represents a decision
-       * - "wait" - a step that requires a waiting period
-       *   in graphical representations of the PCN analysis
-       * - "divergent_process" - a step that requires human judgment
+       * The type of relationship with the predecessor. Must be one of:
+       * - "normal_relationship" - Typically represented on a PCN diagram by
+       *   a solid line.
+       * - "loose_temporal_relationship" - Typically represented on a PCN
+       *   diagram by a dashed line.
        * @type {string}
        */
       "type": "",
 
       /**
-       * An optional boolean that indicates whether or not the process is
-       * relatively more significant.
-       * @type {boolean}
+       * The optional title field provides additional information about the
+       * relationship between the steps. For example, "Yes" or "No" might be
+       * used for steps that are successors to decision steps.
+       * @type {string}
        * @optional
        */
-      "emphasized": false,
+      "title": ""
+    }
+  ],
+
+  /**
+   * The domain field links the step to the domain it is associated with,
+   * which are defined in the top-level domains field.
+   */
+  "domain": {
+
+    /**
+     * The identifier of the domain that the step is associated with.
+     * @type {string}
+     */
+    "id": "",
+
+    /**
+     * The process region that the step is in. An object with the two fields
+     * outlined below.
+     * @type {Object}
+     */
+    "region": {
 
       /**
-       * The value_specific field represents the value realization or value
-       * potential that the specific beneficiary receives during the step. The
-       * value of this field must be an integer (may be negative).
-       * @type {number}
-       * @example 3 (much value realization or potential, perhaps represented by
-       *   three smiley faces on a typical PCN diagram)
-       * @example 0 (no or neutral value realization)
-       * @example -1 (non-monetary cost, perhaps represented graphically by a
-       *   frown face)
+       * The type field identifies the region, and must be one of:
+       * - "independent" - the independent processing region of the domain
+       * - "surrogate" - one of the surrogate regions of the domain
+       * - "direct_TODO" - one of the direct interaction regions of the
+       *   domain, with preference to the domain's side of the region
+       * - "direct" - one of the direct interaction regions of the domain,
+       *   in the middle of the region
+       * See the with_domain field below.
        */
-      "value_specific": 0,
+      "type": "",
 
       /**
-       * The value_generic field is identical to the value_specific field,
-       * except that it represents the value potential or value realization of
-       * the generic beneficiary instead of the specific beneficiary. Positive
-       * values might be represented graphically by dollar signs, and negative
-       * values by dollar signs with negative symbols.
-       * @type {number}
+       * If the above type field is anything but "independent", the
+       * with_domain field is the identifier of the other domain involved
+       * in the process. This field determines which of the two surrogate
+       * or direct regions the step falls under. If the above type field is
+       * "independent", the value of this field should be ignored.
+       * @type {string}
        */
-      "value_generic": 0,
+      "with_domain": ""
+    }
+  },
+
+  /**
+   * The problems field represents potential issues with the step.
+   * @type {Array.<Object>}
+   * @optional
+   */
+  "problems": [
+    {
+      /**
+       * The type of problem must be one of:
+       * - "inconvenient"
+       * - "confusing"
+       * - "difficult"
+       * - "likely_to_fail"
+       * @type {string}
+       */
+      "type": "",
 
       /**
-       * The predecessors field defines relationships between the step and other
-       * steps. The field is optional and will be omitted for steps that have no
-       * predecessors, such as the first step of a process. It will have
-       * multiple entries for steps that are a point of convergence in a
-       * process.
-       * @type {Array.<Object>}
-       * @optional
+       * The description field builds upon the type field and provides the
+       * why or how of the problem.
+       * @type {string}
        */
-      "predecessors": [
-        {
-          /**
-           * The identifier of the predecessor step.
-           * @type {string}
-           */
-          "id": "",
-
-          /**
-           * The type of relationship with the predecessor. Must be one of:
-           * - "normal_relationship" - Typically represented on a PCN diagram by
-           *   a solid line.
-           * - "loose_temporal_relationship" - Typically represented on a PCN
-           *   diagram by a dashed line.
-           * @type {string}
-           */
-          "type": "",
-
-          /**
-           * The optional title field provides additional information about the
-           * relationship between the steps. For example, "Yes" or "No" might be
-           * used for steps that are successors to decision steps.
-           * @type {string}
-           * @optional
-           */
-          "title": ""
-        }
-      ],
-
-      /**
-       * The domain field links the step to the domain it is associated with,
-       * which are defined in the top-level domains field.
-       */
-      "domain": {
-
-        /**
-         * The identifier of the domain that the step is associated with.
-         * @type {string}
-         */
-        "id": "",
-
-        /**
-         * The process region that the step is in. An object with the two fields
-         * outlined below.
-         * @type {Object}
-         */
-        "region": {
-
-          /**
-           * The type field identifies the region, and must be one of:
-           * - "independent" - the independent processing region of the domain
-           * - "surrogate" - one of the surrogate regions of the domain
-           * - "direct_TODO" - one of the direct interaction regions of the
-           *   domain, with preference to the domain's side of the region
-           * - "direct" - one of the direct interaction regions of the domain,
-           *   in the middle of the region
-           * See the with_domain field below.
-           */
-          "type": "",
-
-          /**
-           * If the above type field is anything but "independent", the
-           * with_domain field is the identifier of the other domain involved
-           * in the process. This field determines which of the two surrogate
-           * or direct regions the step falls under. If the above type field is
-           * "independent", the value of this field should be ignored.
-           * @type {string}
-           */
-          "with_domain": ""
-        }
-      },
-
-      /**
-       * The problems field represents potential issues with the step.
-       * @type {Array.<Object>}
-       * @optional
-       */
-      "problems": [
-        {
-          /**
-           * The type of problem must be one of:
-           * - "inconvenient"
-           * - "confusing"
-           * - "difficult"
-           * - "likely_to_fail"
-           * @type {string}
-           */
-          "type": "",
-
-          /**
-           * The description field builds upon the type field and provides the
-           * why or how of the problem.
-           * @type {string}
-           */
-          "description": ""
-        }
-      ]
+      "description": ""
     }
   ]
 }


### PR DESCRIPTION
Split it up to make it easier to read.  Three parts of the specification: top level, domains, and steps.
