### PR TITLE
Fix errors in Example Pizza Parlor JSON

### DIFF
--- a/examples/pizza-parlor.json
+++ b/examples/pizza-parlor.json
@@ -54,7 +54,7 @@
       "predecessors":
       [
         {
-          "id": "GUID_4567",
+          "id": "GUID_3456",
           "type": "normal_relationship",
           "title": ""
         }
@@ -92,7 +92,7 @@
         "id": "GUID_1234",
         "region":
         {
-          "type": "direct_TODO",
+          "type": "direct_shared",
           "with_domain": "GUID_2345"
         }
       },
@@ -148,7 +148,7 @@
         "id": "GUID_2345",
         "region":
         {
-          "type": "direct",
+          "type": "direct_shared",
           "with_domain": "GUID_1234"
         }
       },
@@ -347,7 +347,7 @@
         "id": "GUID_1234",
         "region":
         {
-          "type": "direct_TODO",
+          "type": "direct_shared",
           "with_domain": "GUID_2345"
         }
       },
@@ -403,7 +403,7 @@
         "id": "GUID_1234",
         "region":
         {
-          "type": "direct_TODO",
+          "type": "direct_shared",
           "with_domain": "GUID_2345"
         }
       },
@@ -431,7 +431,7 @@
         "id": "GUID_2345",
         "region":
         {
-          "type": "direct_TODO",
+          "type": "direct_shared",
           "with_domain": "GUID_1234"
         }
       },


### PR DESCRIPTION
The example JSON is not valid according to the spec.  This update makes it valid.
