### PR TITLE
Remove TODO from region type definition

### DIFF
--- a/examples/pizza-parlor.json
+++ b/examples/pizza-parlor.json
@@ -92,7 +92,7 @@
         "id": "GUID_1234",
         "region":
         {
-          "type": "direct_TODO",
+          "type": "direct_shared",
           "with_domain": "GUID_2345"
         }
       },
@@ -347,7 +347,7 @@
         "id": "GUID_1234",
         "region":
         {
-          "type": "direct_TODO",
+          "type": "direct_shared",
           "with_domain": "GUID_2345"
         }
       },
@@ -403,7 +403,7 @@
         "id": "GUID_1234",
         "region":
         {
-          "type": "direct_TODO",
+          "type": "direct_shared",
           "with_domain": "GUID_2345"
         }
       },
@@ -431,7 +431,7 @@
         "id": "GUID_2345",
         "region":
         {
-          "type": "direct_TODO",
+          "type": "direct_leading",
           "with_domain": "GUID_1234"
         }
       },

--- a/examples/pizza-parlor.json
+++ b/examples/pizza-parlor.json
@@ -148,7 +148,7 @@
         "id": "GUID_2345",
         "region":
         {
-          "type": "direct",
+          "type": "direct_leading",
           "with_domain": "GUID_1234"
         }
       },


### PR DESCRIPTION
The spec and the example are out of sync, and this needs to be corrected. I took a crack at it, but it may need a bit of work to be completely correct.
