### PR TITLE
PCN Spec specified according to JSON Schema specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ For complete examples of the standard that use real-world data, please see the [
 
 ## Validation
 
+### PCN Lint
 A PCN Spec validation tool is separately developed and maintained at [pcnlint](https://github.com/pcnsuite/pcnlint). Use pcnlint to ensure JSON is proper according to this specification.
+
+### JSON Schema
+Use the pcnspec_jsonschema.json file to validate a PCN Spec document with any of the many [JSON Schema validators](http://json-schema.org/implementations.html) available.
 
 ## Specification
 

--- a/pcnspec_jsonschema.json
+++ b/pcnspec_jsonschema.json
@@ -2,7 +2,7 @@
   "id": "1.0.0",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "PCN Spec",
-  "description": "Formal JSON-Schema of PCN Spec, usefull for validation of PCN documents",
+  "description": "Formal JSON-Schema of PCN Spec",
   "type": "object",
   "properties": {
     "metadata": {

--- a/pcnspec_jsonschema.json
+++ b/pcnspec_jsonschema.json
@@ -1,0 +1,169 @@
+{
+  "id": "1.0.0",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "PCN Spec",
+  "description": "Formal JSON-Schema of PCN Spec, usefull for validation of PCN documents",
+  "type": "object",
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "author": {
+          "type": "string"
+        }
+      }
+    },
+    "domains": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "subtitle": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "subtitle"
+        ]
+      },
+      "additionalItems": false
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "process",
+              "decision",
+              "wait",
+              "divergent_process"
+            ]
+          },
+          "emphasized": {
+            "type": "boolean",
+            "default": false
+          },
+          "value_specific": {
+            "type": "integer",
+            "default": 0
+          },
+          "value_generic": {
+            "type": "integer",
+            "default": 0
+          },
+          "predecessors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "normal_relationship",
+                    "loose_temporal_relationship"
+                  ]
+                },
+                "title": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "type"
+              ]
+            }
+          },
+          "domain": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "region": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "independent",
+                      "surrogate",
+                      "direct_leading",
+                      "direct_shared"
+                    ]
+                  },
+                  "with_domain": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "with_domain"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "region"
+            ]
+          },
+          "problems": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "inconvenient",
+                    "confusing",
+                    "difficult",
+                    "likely_to_fail"
+                  ]
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "type",
+          "domain"
+        ]
+      },
+      "additionalItems": false
+    }
+  },
+  "required": [
+    "domains",
+    "steps"
+  ]
+}


### PR DESCRIPTION
I wrote the PCN Spec in [JSON Schema](http://json-schema.org/) format. JSON Schema is a draft standard approved by the IETF for specifying the format of JSON documents. Using this schema, a PCN Spec document can be validated using tools written in 14 languages. [Other tools](http://json-schema.org/implementations.html) such as UI generators are also available.

You can try it out using this tool:
http://json-schema-validator.herokuapp.com/
